### PR TITLE
Workflow to create PR for sync Upstream repo changes

### DIFF
--- a/.github/workflows/fetch-upstream-origin-changes.yml
+++ b/.github/workflows/fetch-upstream-origin-changes.yml
@@ -1,0 +1,34 @@
+name: Sync Upstream
+
+on:
+  workflow_call:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/fiterpaystack/fineract.git
+
+      - name: Fetch upstream
+        run: git fetch upstream
+
+      - name: Create sync branch
+        run: |
+          git checkout -B sync-upstream upstream/develop
+          git push origin sync-upstream --force
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'Sync from fiterpaystack/fineract upstream repo'
+          branch: sync-upstream
+          title: '🔄 Sync from fiterpaystack/fineract'
+          body: 'Sync from upstream repo(fiterpaystack/fineract)'

--- a/.github/workflows/fetch-upstream-origin-changes.yml
+++ b/.github/workflows/fetch-upstream-origin-changes.yml
@@ -3,6 +3,11 @@ name: Sync Upstream
 on:
   workflow_call:
 
+env:
+  UPSTREAM_BRANCH: develop
+  UPSTREAM_URL: https://github.com/fiterpaystack/fineract.git
+  UPSTREAM_REPO: fiterpaystack/fineract
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -14,21 +19,21 @@ jobs:
           fetch-depth: 0
 
       - name: Add upstream remote
-        run: git remote add upstream https://github.com/fiterpaystack/fineract.git
+        run: git remote add upstream ${{ env.UPSTREAM_URL }}
 
       - name: Fetch upstream
         run: git fetch upstream
 
       - name: Create sync branch
         run: |
-          git checkout -B sync-upstream upstream/develop
+          git checkout -B sync-upstream upstream/${{ env.UPSTREAM_BRANCH }}
           git push origin sync-upstream --force
 
       - name: Create PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'Sync from fiterpaystack/fineract upstream repo'
+          commit-message: 'Sync from ${{ env.UPSTREAM_REPO }} upstream repo'
           branch: sync-upstream
-          title: '🔄 Sync from fiterpaystack/fineract'
-          body: 'Sync from upstream repo(fiterpaystack/fineract)'
+          title: '🔄 Sync from ${{ env.UPSTREAM_REPO }}'
+          body: 'Sync from upstream repo(${{ env.UPSTREAM_REPO }})'


### PR DESCRIPTION
- Creating this workflow to create PR for Sync Upstream repo(fiterpaystack/fineract)

Context:
We are switching the Paystack-MFB/fineract repository to private because it's currently public, which is causing blockers for running certain build and deployment workflows.

Plan:

Remove the fork from the Paystack-MFB/fineract repo and make it private.
Use this workflow to fetching changes from the upstream repository into our private fineract repo.

[JiraTicket](https://paystack.atlassian.net/browse/IDEVOPS-1427)